### PR TITLE
Fix: 한국도로공사 API xValue/yValue 좌표 추출 오류 수정

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -61,7 +61,8 @@
       "Bash(npx eslint:*)",
       "Bash(sed:*)",
       "Bash(git checkout:*)",
-      "Bash(git merge:*)"
+      "Bash(git merge:*)",
+      "Bash(git branch:*)"
     ],
     "deny": []
   }

--- a/hyugepick/src/lib/utils/coordinateValidator.ts
+++ b/hyugepick/src/lib/utils/coordinateValidator.ts
@@ -68,11 +68,22 @@ export function extractCoordinates(data: any): Coordinates | null {
     return { lat: data.y, lng: data.x };
   }
 
+  // xValue, yValue 형태인 경우 (한국도로공사 API에서 사용)
+  if (data?.xValue && data?.yValue) {
+    const lng = parseFloat(data.xValue);
+    const lat = parseFloat(data.yValue);
+    if (isValidLatLng(lat, lng)) {
+      return { lat, lng };
+    }
+  }
+
   console.warn('extractCoordinates: 유효한 좌표를 찾을 수 없습니다', {
     data,
     hasLat: 'lat' in (data || {}),
     hasLng: 'lng' in (data || {}),
     hasCoordinates: 'coordinates' in (data || {}),
+    hasXValue: 'xValue' in (data || {}),
+    hasYValue: 'yValue' in (data || {}),
     coordinatesType: typeof data?.coordinates
   });
   


### PR DESCRIPTION
- coordinateValidator.ts에 xValue, yValue 형태 처리 추가
- Vercel 배포 환경에서 휴게소 좌표 추출 실패 문제 해결